### PR TITLE
Splice using index of subscriber ID, not ID itself

### DIFF
--- a/src/native/utils/game-loop.js
+++ b/src/native/utils/game-loop.js
@@ -22,6 +22,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    this.subscribers.splice(this.subscribers.indexOf(id), 1);
+    delete this.subscribers[id - 1];
   }
 }

--- a/src/native/utils/game-loop.js
+++ b/src/native/utils/game-loop.js
@@ -22,6 +22,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    this.subscribers.splice((id - 1), 1);
+    this.subscribers.splice(this.subscribers.indexOf(id), 1);
   }
 }

--- a/src/utils/game-loop.js
+++ b/src/utils/game-loop.js
@@ -22,6 +22,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    this.subscribers.splice(this.subscribers.indexOf(id), 1);
+    delete this.subscribers[id - 1];
   }
 }

--- a/src/utils/game-loop.js
+++ b/src/utils/game-loop.js
@@ -22,6 +22,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    this.subscribers.splice((id - 1), 1);
+    this.subscribers.splice(this.subscribers.indexOf(id), 1);
   }
 }


### PR DESCRIPTION
Loop subscribers are given an ID to later unsubscribe with, but the current `unsubscribe` function uses those IDs as indexes to `splice` out of the list of `subscribers`. This leads to the wrong subscriber often being `splice`d out if the index of the ID had changed with a previous `unsubscribe` call.