### PR TITLE
Surface display width and height in stage context

### DIFF
--- a/src/components/stage.js
+++ b/src/components/stage.js
@@ -21,6 +21,8 @@ export default class Stage extends Component {
   static childContextTypes = {
     loop: PropTypes.object,
     scale: PropTypes.number,
+    renderWidth: PropTypes.number,
+    renderHeight: PropTypes.number,
   };
 
   setDimensions = () => {
@@ -52,8 +54,11 @@ export default class Stage extends Component {
   }
 
   getChildContext() {
+    const { scale, width, height } = this.getScale();
     return {
-      scale: this.getScale().scale,
+      scale: scale,
+      renderWidth: width,
+      renderHeight: height,
       loop: this.context.loop,
     };
   }


### PR DESCRIPTION
Avoids recalculating these dimensions somewhere else down the hierarchy. Especially useful if implementing a canvas based renderer:

```javascript
  render() {
    return (
      <World onInit={this.onWorldInit}>
        <canvas
          width={this.context.renderWidth}
          height={this.context.renderWidth}
          ref={element => this.renderTarget = element}
        />
      </World>
    )
  }
```