### PR TITLE
Replace date.now with performance.now

### DIFF
--- a/src/components/world.js
+++ b/src/components/world.js
@@ -1,9 +1,8 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 
-import Matter, { Engine, Events } from 'matter-js';
+import Matter, {Engine, Events} from 'matter-js';
 
 export default class World extends Component {
-
   static propTypes = {
     children: PropTypes.any,
     gravity: PropTypes.shape({
@@ -37,8 +36,12 @@ export default class World extends Component {
   };
 
   loop = () => {
-    const currTime = 0.001 * Date.now();
-    Engine.update(this.engine, 1000 / 60, this.lastTime ? currTime / this.lastTime : 1);
+    const currTime = 0.001 * performance.now();
+    Engine.update(
+      this.engine,
+      1000 / 60,
+      this.lastTime ? currTime / this.lastTime : 1,
+    );
     this.lastTime = currTime;
   };
 
@@ -48,7 +51,7 @@ export default class World extends Component {
     this.loopID = null;
     this.lastTime = null;
 
-    const world = Matter.World.create({ gravity: props.gravity });
+    const world = Matter.World.create({gravity: props.gravity});
 
     this.engine = Engine.create({
       world,
@@ -56,7 +59,7 @@ export default class World extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { gravity } = nextProps;
+    const {gravity} = nextProps;
 
     if (gravity !== this.props.gravity) {
       this.engine.world.gravity = gravity;
@@ -97,5 +100,4 @@ export default class World extends Component {
       </div>
     );
   }
-
 }

--- a/src/native/components/world.js
+++ b/src/native/components/world.js
@@ -1,11 +1,10 @@
-import React, { Component, PropTypes } from 'react';
+import React, {Component, PropTypes} from 'react';
 
-import { View } from 'react-native';
+import {View} from 'react-native';
 
-import Matter, { Engine, Events } from 'matter-js';
+import Matter, {Engine, Events} from 'matter-js';
 
 export default class World extends Component {
-
   static propTypes = {
     children: PropTypes.any,
     gravity: PropTypes.shape({
@@ -39,8 +38,12 @@ export default class World extends Component {
   };
 
   loop = () => {
-    const currTime = 0.001 * Date.now();
-    Engine.update(this.engine, 1000 / 60, this.lastTime ? currTime / this.lastTime : 1);
+    const currTime = 0.001 * performance.now();
+    Engine.update(
+      this.engine,
+      1000 / 60,
+      this.lastTime ? currTime / this.lastTime : 1,
+    );
     this.lastTime = currTime;
   };
 
@@ -50,7 +53,7 @@ export default class World extends Component {
     this.loopID = null;
     this.lastTime = null;
 
-    const world = Matter.World.create({ gravity: props.gravity });
+    const world = Matter.World.create({gravity: props.gravity});
 
     this.engine = Engine.create({
       world,
@@ -58,7 +61,7 @@ export default class World extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    const { gravity } = nextProps;
+    const {gravity} = nextProps;
 
     if (gravity !== this.props.gravity) {
       this.engine.world.gravity = gravity;
@@ -95,5 +98,4 @@ export default class World extends Component {
       </View>
     );
   }
-
 }


### PR DESCRIPTION
this was listed as a nice to have in lighthouse for PWA, since it decouples from system clock and is more consistent

More details - https://developers.google.com/web/tools/lighthouse/audits/date-now

Looks like prettier-eslint got a little zealous, if need I can revert the stylistic changes. 