### PR TITLE
fixed GameLoop stop function

### DIFF
--- a/src/native/utils/game-loop.js
+++ b/src/native/utils/game-loop.js
@@ -16,7 +16,10 @@ export default class GameLoop {
     }
   }
   stop() {
-    window.cancelAnimationFrame(this.loop);
+    if (!this.loopID) {
+      window.cancelAnimationFrame(this.loopID);
+      this.loopID = null;
+    }
   }
   subscribe(callback) {
     return this.subscribers.push(callback);

--- a/src/native/utils/game-loop.js
+++ b/src/native/utils/game-loop.js
@@ -25,6 +25,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    delete this.subscribers[id - 1];
+    this.subscribers.splice((id - 1), 1);
   }
 }

--- a/src/utils/game-loop.js
+++ b/src/utils/game-loop.js
@@ -16,7 +16,10 @@ export default class GameLoop {
     }
   }
   stop() {
-    window.cancelAnimationFrame(this.loopID);
+    if (!this.loopID) {
+      window.cancelAnimationFrame(this.loopID);
+      this.loopID = null;
+    }
   }
   subscribe(callback) {
     return this.subscribers.push(callback);

--- a/src/utils/game-loop.js
+++ b/src/utils/game-loop.js
@@ -25,6 +25,6 @@ export default class GameLoop {
     return this.subscribers.push(callback);
   }
   unsubscribe(id) {
-    delete this.subscribers[id - 1];
+    this.subscribers.splice((id - 1), 1);
   }
 }


### PR DESCRIPTION
In native side, cancelAnimationFrame takes request id and after stoping, loopId should be assigned to null in case of need to restart