### PR TITLE
Fix: removed last performance.now() from the codebase

### DIFF
--- a/src/native/components/world.js
+++ b/src/native/components/world.js
@@ -39,7 +39,7 @@ export default class World extends Component {
   };
 
   loop = () => {
-    const currTime = 0.001 * performance.now();
+    const currTime = 0.001 * Date.now();
     Engine.update(
       this.engine,
       1000 / 60,


### PR DESCRIPTION
`performance` is undefined on Android, when running react-game-kit's with react-native bindings, it simply throws & fails.

It has been removed from the rest of the codebase a few days ago, but one instance remained.
This fixes that.

Closes https://github.com/FormidableLabs/react-game-kit/issues/41