### PR TITLE
fixed minor native bugs

### DIFF
--- a/src/native/utils/game-loop.js
+++ b/src/native/utils/game-loop.js
@@ -2,6 +2,7 @@ export default class GameLoop {
   constructor() {
     this.subscribers = [];
     this.loopID = null;
+    this.loop = this.loop.bind(this);
   }
 
   start() {
@@ -22,7 +23,7 @@ export default class GameLoop {
   }
 
   unsubscribe(id) {
-    this.subscribers.splice((id - 1), 1);
+    delete this.subscribers[id - 1];
   }
 
   loop() {


### PR DESCRIPTION
This PR addresses 2 main issues:
1. The `loop` function in `src/native/utils/game-loop.js` has been changed from arrow function to regular function, but `this` is not bound to the function, resulting in issue https://github.com/FormidableLabs/react-game-kit/issues/56.
2. The `unsubscribe` function in `src/native/utils/game-loop.js` currently uses `splice` instead of `delete`. This causes an app crash, for example when a subscriber in the middle of the array gets removed before another subscriber at the end of the array, as the ID returned during subscription will no longer be valid, and so the callback will not get removed.

-----

Closes #56