### PR TITLE
Update README.md to reflect actual Loop API

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,11 @@ class ChildComponent extends React.Component {
   };
 
   componentDidMount() {
-    this.context.loop.subscribe(this.update);
+    this.loopID = this.context.loop.subscribe(this.update);
   }
 
   componentWillUnmount() {
-    this.context.loop.unsubscribe(this.update);
+    this.context.loop.unsubscribe(this.loopID);
   }
 
   update() {


### PR DESCRIPTION
Loop.unsubscribe(id) accepts an integer (an index, specifically) returned by Loop.subscribe(fn), not a function reference.