### PR TITLE
Make loop.stop() actually stop

### DIFF
--- a/src/utils/game-loop.js
+++ b/src/utils/game-loop.js
@@ -20,7 +20,7 @@ export default class GameLoop {
   }
 
   stop() {
-    if (!this.loopID) {
+    if (this.loopID) {
       window.cancelAnimationFrame(this.loopID);
       this.loopID = null;
     }


### PR DESCRIPTION
It is impossible to stop the loop as there will always be a `loopID` when it is running.