### PR TITLE
Demo crashed on slow network

### DIFF
--- a/demo/game/index.js
+++ b/demo/game/index.js
@@ -38,7 +38,9 @@ export default class Game extends Component {
   }
 
   componentWillUnmount() {
-    this.stopMusic();
+    if(this.stopMusic){
+      this.stopMusic();
+    }
     this.keyListener.unsubscribe();
   }
 


### PR DESCRIPTION
An error occured when entering too quickly in a "house". It executes `componentWillUnMount` which calls `stopMusic` but the latter is only defined when the wav file is loaded. Therefore on slow network it leads to crash.

![Peek 2019-03-14 17-23](https://user-images.githubusercontent.com/7012571/54374900-5c4fc280-4680-11e9-8d5b-837d4071c464.gif)


I created this small PR to fix that.