### PR TITLE
Fixed react-native under expo-web image size issue

### DIFF
--- a/src/native/components/sprite.js
+++ b/src/native/components/sprite.js
@@ -59,7 +59,7 @@ export default class Sprite extends Component {
   }
 
   UNSAFE_componentWillReceiveProps(nextProps) {
-    return componentWillReceiveProps(nextProps)
+    return this.componentWillReceiveProps(nextProps)
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/native/components/sprite.js
+++ b/src/native/components/sprite.js
@@ -17,6 +17,8 @@ export default class Sprite extends Component {
     ticksPerFrame: PropTypes.number,
     tileHeight: PropTypes.number,
     tileWidth: PropTypes.number,
+    sourceHeight: PropTypes.number,
+    sourceWidth: PropTypes.number
   };
 
   static defaultProps = {
@@ -29,6 +31,8 @@ export default class Sprite extends Component {
     ticksPerFrame: 4,
     tileHeight: 64,
     tileWidth: 64,
+    sourceHeight: 64,
+    sourceWidth: 64
   };
 
   static contextTypes = {
@@ -52,6 +56,10 @@ export default class Sprite extends Component {
     this.props.onPlayStateChanged(1);
     const animate = this.animate.bind(this, this.props);
     this.loopID = this.context.loop.subscribe(animate);
+  }
+
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    return componentWillReceiveProps(nextProps)
   }
 
   componentWillReceiveProps(nextProps) {
@@ -109,6 +117,8 @@ export default class Sprite extends Component {
 
     return {
       position: 'absolute',
+      height: this.props.sourceHeight,
+      width: this.props.sourceWidth,
       transform: [
         { translateX: left * -1 },
         { translateY: top * -1 },


### PR DESCRIPTION
1. Under expo web, react native incorrectly resize div with the image in the background. Fixed size should be set.
2. Fix for react 17 lifecycle